### PR TITLE
Address `CancelledError` bug in #28

### DIFF
--- a/src/batch_llm/experiment_processing.py
+++ b/src/batch_llm/experiment_processing.py
@@ -356,7 +356,7 @@ async def query_model_and_record_response(
         index = "NA"
 
     # query the API
-    timeout_seconds = 600
+    timeout_seconds = 300
     # attempt to query the API max_attempts times (for timeout errors)
     # if response or another error is received, only try once and break out of the loop
     try:
@@ -379,7 +379,7 @@ async def query_model_and_record_response(
         # fill in response with error message
         completed_prompt_dict = prompt_dict
         completed_prompt_dict["response"] = f"{type(err).__name__} - {err}"
-    except (Exception, asyncio.CancelledError) as err:
+    except (Exception, asyncio.CancelledError, asyncio.TimeoutError) as err:
         if attempt == settings.max_attempts:
             # we've already tried max_attempts times, so log the error and save an error response
             log_message = (


### PR DESCRIPTION
This is a first draft for a fix for #28 .

Other things to discuss and maybe implement would be:
- Find a way to set the http request timeout (the request is currently wrapped by the openAI sdk call to the API).
- The request timeout should probably be always less than the asyncio timeout? Because ideally we shouldn't be cleanly handling `CancelledError`, which Python have chosen to inherit from `BaseException`.
   - See this [stackoverflow](https://stackoverflow.com/questions/60745841/inheriting-from-baseexception-vs-exception) and PEP linked within.
- If we find a way to set the request timeout error and ensure it is < asyncio timeout, then we should re-raise `CancelledError` with a more informative application level error message.