### PR TITLE
Ollama sort

### DIFF
--- a/src/prompto/models/ollama/ollama_utils.py
+++ b/src/prompto/models/ollama/ollama_utils.py
@@ -16,3 +16,51 @@ def process_response(response: dict) -> str:
         return response["response"]
     else:
         raise ValueError(f"Unsupported response type: {type(response)}")
+
+
+def sort_ollama_prompts(prompt_dicts: list[dict]) -> list[dict]:
+    """
+    For a list of prompt dictionaries, sort the dictionaries with "api": "ollama"
+    by the "model_name" key. The rest of the dictionaries are kept in the same order.
+
+    For Ollama API, if the model requested is not currently loaded, the model will be
+    loaded on demand. This can take some time, so it is better to sort the prompts
+    by the model name to reduce the time taken to load the models.
+
+    If no "ollama" dictionaries are present, the original list is returned.
+
+    Parameters
+    ----------
+    prompt_dicts : list[dict]
+        List of dictionaries containing the prompt and other parameters
+        to be sent to the API. Each dictionary must have keys "prompt" and "api".
+
+    Returns
+    -------
+    list[dict]
+        List of dictionaries containing the prompt and other parameters
+        where the "ollama" dictionaries are sorted by the "model_name" key
+    """
+    ollama_indices = [
+        i for i, item in enumerate(prompt_dicts) if item.get("api") == "ollama"
+    ]
+    if len(ollama_indices) == 0:
+        return prompt_dicts
+
+    # sort indices for "ollama" dictionaries
+    sorted_ollama_indices = sorted(
+        ollama_indices, key=lambda i: prompt_dicts[i].get("model_name", "")
+    )
+
+    # create map from original ollama index to sorted index
+    ollama_index_map = {i: j for i, j in zip(ollama_indices, sorted_ollama_indices)}
+
+    # sort data based on the combined indices
+    return [
+        (
+            prompt_dicts[i]
+            if i not in ollama_index_map.keys()
+            else prompt_dicts[ollama_index_map[i]]
+        )
+        for i in range(len(prompt_dicts))
+    ]


### PR DESCRIPTION
Fix #51.

We now have a function `_sort_ollama_prompts` (maybe thinking this should be in `ollama_utils` actually?) which will look for the indices in our list of `prompt_dict`s for ones with `"api": "ollama"`. In the case there are some, we sort them by `model_name` otherwise no sorting is necessary. This gives us a mapping from old indices to new sorted indices for our ollama prompts which we then use to sort the full list.

We keep the other indices for other models the same. That is, only indices for ollama models are changed.

I think this could be useful to keep the other indices for other APIs/models the same because if you're not processing in parallel (i.e. `-p` flag not used in the command), it might be good to interweave the calls so we won't change the order of those. We only care about fixing the ollama order I think. It should generally be on the user to optimise the order but for ollama, we can apply this.